### PR TITLE
Update Header.js

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -80,7 +80,7 @@ function Header() {
           )}
           {viewResume && (
             <li>
-              <a href="#resume">Resume</a>
+              <a href="https://drive.google.com/file/d/1QFFbg795ujOQfPcJDnnUzz4ApWnt_RKG/view">Resume</a>
             </li>
           )}
           <li>


### PR DESCRIPTION
Added the resume link to the header resume button

# Description

It was initially referenced to _#resume_. I changed it to the google link

Fixes # (issue)

Just added the resume link from your profile